### PR TITLE
changed run_on_change() to run_on_changes()

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "guard"
+gem "guard", "~> 1.1"
 
 group :development, :test do
   gem 'rake'

--- a/lib/guard/rack.rb
+++ b/lib/guard/rack.rb
@@ -45,7 +45,7 @@ module Guard
       runner.stop
     end
 
-    def run_on_change(paths)
+    def run_on_changes(paths)
       reload
     end
   end

--- a/spec/lib/guard/rack_spec.rb
+++ b/spec/lib/guard/rack_spec.rb
@@ -82,10 +82,10 @@ describe Guard::Rack do
     end
   end
 
-  describe '#run_on_change' do
+  describe '#run_on_changes' do
     it "should reload on change" do
       guard.expects(:reload).once
-      guard.run_on_change([])
+      guard.run_on_changes([])
     end
   end
 end


### PR DESCRIPTION
Stops a DEPRECATED warning when using against Guard v1.1

Literally just adding an 's' onto the end of run_on_change()
