### PR TITLE
Using :server option

### DIFF
--- a/lib/guard/rack/runner.rb
+++ b/lib/guard/rack/runner.rb
@@ -51,7 +51,7 @@ module Guard
       when "mongrel", "webrick"
         rack_options << "--server #{options[:server]}"
       when "thin"
-        command = "thin start"
+        command = "thin start -r config.ru"
       when "unicorn"
         command = "unicorn"
       end


### PR DESCRIPTION
dB,

This is my first pr on a gem. If there's some standard stuff missing, I'll readily make changes.

The RackRunner now takes the server option into account. For unicorn and thin, it uses commands other than rackup. For webrick/mongrel, it just passes the server arg to rackup.

Suggestions?
