### PR TITLE
Remove the explicit dependencies on notify gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * [#17](https://github.com/dblock/guard-rack/pull/17): Added ability to specify host - [@jwhitcraft](https://github.com/jwhitcraft).
+* [#18](https://github.com/dblock/guard-rack/pull/18): Removed explicit dependencies on notification libraries, relying instead on Guard's default behavior - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 2.0.0 (11/15/2014)

--- a/guard-rack.gemspec
+++ b/guard-rack.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'guard', '~> 2.3'
   gem.add_dependency 'ffi'
   gem.add_dependency 'spoon'
-  gem.add_dependency 'rb-inotify'
-  gem.add_dependency 'libnotify'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bundler'


### PR DESCRIPTION
Guard wraps all of the notification stuff in some safe requires in older
versions (>= 2.3, < 2.11) and then extracts that behavior into Notiffany
after 2.11. This safe require behavior raises an error if the
appropriate library isn't installed, which -- to me at least -- is
acceptable behavior, since guard is a development tool anyway and won't
be run "in production".

The explicit requires cause havoc with using guard-rack in a vagrant
environment I'm working on. Just removing the explicit requires allows
me to run Guard in vagrant without issues. It also displays the
notifications properly to my notification daemon (I'm assuming via
libnotify, since I have it installed).

Do you agree that the message of "hey, you're missing a gem -- go
install it!" is an acceptable course of action?