### PR TITLE
Add support for a customizable rackup command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * [#17](https://github.com/dblock/guard-rack/pull/17): Added ability to specify host - [@jwhitcraft](https://github.com/jwhitcraft).
 * [#18](https://github.com/dblock/guard-rack/pull/18): Removed explicit dependencies on notification libraries, relying instead on Guard's default behavior - [@michaelherold](https://github.com/michaelherold).
+* [#19](https://github.com/dblock/guard-rack/pull/19): Added the ability to specify the command for mounting the Rack application - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 2.0.0 (11/15/2014)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Want to restart your Rack development with *rackup* whilst you work? Now you can
 Options
 -------
 
+* `:cmd` is the command to run to mount the Rack application (default `rackup`).
 * `:host` is the host ip address to run on (default `0.0.0.0`).
 * `:port` is the port number to run on (default `9292`).
 * `:environment` is the environment to use (default `development`).
@@ -37,5 +38,5 @@ Copyright and License
 
 MIT License, see [LICENSE](http://github.com/dblock/guard-rack/raw/master/LICENSE.md) for details.
 
-(c) 2012-2014 [Daniel Doubrovkine](http://github.com/dblock) and [Contributors](https://github.com/dblock/guard-rack/graphs/contributors).
+(c) 2012-2015 [Daniel Doubrovkine](http://github.com/dblock) and [Contributors](https://github.com/dblock/guard-rack/graphs/contributors).
 

--- a/lib/guard/rack.rb
+++ b/lib/guard/rack.rb
@@ -15,7 +15,8 @@ module Guard
       force_run: false,
       timeout: 20,
       debugger: false,
-      config: 'config.ru'
+      config: 'config.ru',
+      cmd: 'rackup'
     }
 
     def initialize(options = {})

--- a/lib/guard/rack/command.rb
+++ b/lib/guard/rack/command.rb
@@ -1,0 +1,64 @@
+require 'guard/rack'
+
+module Guard
+  class Rack < Plugin
+    class Command < String
+      attr_reader :options
+
+      def initialize(options = {})
+        @options = options
+        super(build.join(' '))
+      end
+
+      private
+
+      def build
+        cmd = [options[:cmd]]
+
+        cmd << configuration
+        cmd << environment
+        cmd << host
+        cmd << port
+        cmd << daemon
+        cmd << debug
+        cmd << server
+
+        cmd.flatten.compact
+      end
+
+      def configuration
+        [options[:config]]
+      end
+
+      def daemon
+        return unless options[:daemon]
+
+        ['--daemonize', options[:daemon]]
+      end
+
+      def debug
+        return unless options[:debugger]
+
+        ['--debug', options[:debugger]]
+      end
+
+      def environment
+        ['--env', options[:environment]]
+      end
+
+      def host
+        ['--host', options[:host]]
+      end
+
+      def port
+        ['--port', options[:port]]
+      end
+
+      def server
+        return unless options[:server]
+
+        ['--server', options[:server]]
+      end
+    end
+  end
+end

--- a/lib/guard/rack/runner.rb
+++ b/lib/guard/rack/runner.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'timeout'
 require 'spoon'
+require 'guard/rack/command'
 
 module Guard
   class RackRunner
@@ -36,22 +37,6 @@ module Guard
 
     private
 
-    def build_rack_command
-      command = %w(rackup)
-      command.push(
-        options[:config],
-        '--env', options[:environment].to_s,
-        '--host', options[:host].to_s,
-        '--port', options[:port].to_s
-      )
-
-      command << '--daemonize' if options[:daemon]
-      command << '--debug' if options[:debugger]
-      command.push('--server', options[:server].to_s) if options[:server]
-
-      command
-    end
-
     def kill(pid, force = false)
       result = -1
 
@@ -76,8 +61,8 @@ module Guard
     end
 
     def run_rack_command!
-      command = build_rack_command
-      UI.debug("Running Rack with command: #{command.inspect}")
+      command = Guard::Rack::Command.new(options)
+      UI.debug("Running Rack with command: #{command}")
       spawn(*command)
     end
 

--- a/spec/lib/guard/integration_spec.rb
+++ b/spec/lib/guard/integration_spec.rb
@@ -3,7 +3,7 @@ require 'guard/rack/runner'
 
 describe 'Integration' do
   let(:runner) { Guard::RackRunner.new(options) }
-  let(:options) { { environment: 'development', port: 3000, config: 'spec/lib/guard/integration.ru' } }
+  let(:options) { { cmd: 'rackup', environment: 'development', port: 3000, config: 'spec/lib/guard/integration.ru' } }
 
   describe '#start' do
     context 'run' do

--- a/spec/lib/guard/rack/command_spec.rb
+++ b/spec/lib/guard/rack/command_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Guard::Rack::Command do
+  let(:default_options) do
+    { cmd: 'rackup', environment: 'development', host: '0.0.0.0',
+      port: 3000, config: 'config.ru' }
+  end
+  let(:options) { default_options }
+  let(:command) { Guard::Rack::Command.new(options) }
+
+  describe '.initialize' do
+    subject { command }
+
+    it { is_expected.to start_with('rackup') }
+    it { is_expected.to include('config.ru') }
+    it { is_expected.to include('--env development') }
+    it { is_expected.to include('--host 0.0.0.0') }
+    it { is_expected.to include('--port 3000') }
+    it { is_expected.not_to include('--daemonize') }
+    it { is_expected.not_to include('--debug') }
+    it { is_expected.not_to include('--server') }
+
+    context 'with a custom command configuration' do
+      let(:options) { default_options.merge(cmd: 'bundle exec rackup') }
+
+      it { is_expected.to start_with('bundle exec rackup') }
+    end
+
+    context 'with a daemon configuration' do
+      let(:options) { default_options.merge(daemon: true) }
+
+      it { is_expected.to include('--daemonize') }
+    end
+
+    context 'with a debugger configuration' do
+      let(:options) { default_options.merge(debugger: true) }
+
+      it { is_expected.to include('--debug') }
+    end
+
+    context 'with an environment configuration' do
+      let(:options) { default_options.merge(environment: 'custom') }
+
+      it { is_expected.to include('--env custom') }
+    end
+
+    context 'with a server configuration' do
+      let(:options) { default_options.merge(server: 'thin') }
+
+      it { is_expected.to include('--server thin') }
+    end
+
+    context 'with a custom config file configuration' do
+      let(:options) { default_options.merge(config: 'config2.ru') }
+
+      it { is_expected.to include('config2.ru') }
+    end
+  end
+end

--- a/spec/lib/guard/runner_spec.rb
+++ b/spec/lib/guard/runner_spec.rb
@@ -34,73 +34,6 @@ describe Guard::RackRunner do
     end
   end
 
-  describe '#build_rack_command' do
-    context 'no daemon' do
-      it 'should not have a daemon switch' do
-        expect(runner.send(:build_rack_command)).not_to include('--daemonize')
-      end
-    end
-
-    context 'daemon' do
-      let(:options) { default_options.merge(daemon: true) }
-
-      it 'should have a daemon switch' do
-        expect(runner.send(:build_rack_command)).to include('--daemonize')
-      end
-    end
-
-    context 'debugger' do
-      let(:options) { default_options.merge(debugger: true) }
-
-      it 'should have a debugger switch' do
-        expect(runner.send(:build_rack_command)).to include('--debug')
-      end
-    end
-
-    context 'server' do
-      let(:options) { default_options.merge(server: 'thin') }
-
-      it 'should honour server switch' do
-        command = runner.send(:build_rack_command)
-        index = command.index('--server')
-        expect(index).to be >= 0
-        expect(command[index + 1]).to eq('thin')
-      end
-    end
-
-    context 'config file' do
-      context 'default' do
-        it 'should default to config.ru' do
-          expect(runner.send(:build_rack_command)).to include('config.ru')
-        end
-      end
-
-      context 'custom' do
-        let(:options) { default_options.merge(config: 'config2.ru') }
-        it 'should honour config option' do
-          default_options.merge(config: 'config2.ru')
-          expect(runner.send(:build_rack_command)).to include('config2.ru')
-        end
-      end
-    end
-
-    context 'host' do
-      context 'default' do
-        it 'should default to 0.0.0.0' do
-          expect(runner.send(:build_rack_command)).to include('0.0.0.0')
-        end
-      end
-
-      context 'custom' do
-        let(:options) { default_options.merge(host: '127.0.0.0') }
-        it 'should honour config option' do
-          default_options.merge(host: '127.0.0.0')
-          expect(runner.send(:build_rack_command)).to include('127.0.0.0')
-        end
-      end
-    end
-  end
-
   describe '#start' do
     let(:unmanaged_pid) { 4567 }
     let(:pid) { 1234 }
@@ -136,7 +69,6 @@ describe Guard::RackRunner do
   end
 
   describe '#stop' do
-
     context 'pid exists' do
       let(:pid) { 12_345 }
       let(:status_stub) { stub('process exit status') }


### PR DESCRIPTION
Instead of adding detection of a Gemfile and heuristics around when to
run `bundle exec rackup` vs. plain `rackup`, I figured it would be
better to go the way of guard-rspec and just allow the user to specify
the command that they want to run.

This also refactors the command builder into its own class to reduce the
complexity of the runner class and better encapsulate the logic.

Fixes #1