### PR TITLE
Fix resolution of the Guard namespace.

### DIFF
--- a/lib/guard/rack/runner.rb
+++ b/lib/guard/rack/runner.rb
@@ -61,7 +61,7 @@ module Guard
     end
 
     def run_rack_command!
-      command = Guard::Rack::Command.new(options).build
+      command = ::Guard::Rack::Command.new(options).build
       UI.debug("Running Rack with command: #{command}")
       spawn(*command)
     end


### PR DESCRIPTION
I have no idea why. It happened on ruby 2.2.