### PR TITLE
handle windows platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * Your contribution here.
+* [#23](https://github.com/dblock/guard-rack/pull/23) Supports Windows - [@jonyeezs](https://github.com/jonyeezs)
 
 2.1.1 (03/07/2015)
 ============
@@ -60,4 +61,3 @@
 ================
 
 * Initial public release - [@dblock](https://github.com/dblock).
-

--- a/lib/guard/rack.rb
+++ b/lib/guard/rack.rb
@@ -8,15 +8,15 @@ module Guard
     attr_reader :options, :runner
 
     DEFAULT_OPTIONS = {
-      port: 9292,
-      host: '0.0.0.0',
-      environment: 'development',
+      port:           9292,
+      host:           '0.0.0.0',
+      environment:    'development',
       start_on_start: true,
-      force_run: false,
-      timeout: 20,
-      debugger: false,
-      config: 'config.ru',
-      cmd: 'rackup'
+      force_run:      false,
+      timeout:        20,
+      debugger:       false,
+      config:         'config.ru',
+      cmd:            'rackup'
     }
 
     def initialize(options = {})

--- a/lib/guard/rack/custom_process.rb
+++ b/lib/guard/rack/custom_process.rb
@@ -1,0 +1,59 @@
+require 'timeout'
+
+module Guard
+  class Rack
+    class CustomProcess
+      attr_reader :options
+
+      def self.new(options = {})
+        if Gem.win_platform?
+          os_instance = Windows.allocate
+        else
+          os_instance = Nix.allocate
+        end
+        os_instance.send :initialize, options
+        os_instance
+      end
+
+      def initialize(options)
+        @options = options
+      end
+
+      class Nix < Rack::CustomProcess
+        def kill(pid, force = false)
+          result = -1
+          UI.debug("Trying to kill Rack (PID #{pid})...")
+          unless force
+            Process.kill('INT', pid)
+            begin
+              Timeout.timeout(options[:timeout]) do
+                _, status = Process.wait2(pid)
+                result = status.exitstatus
+                UI.debug("Killed Rack (Exit status: #{result})")
+              end
+            rescue Timeout::Error
+              UI.debug("Couldn't kill Rack with INT, switching to TERM")
+              force = true
+            end
+          end
+          Process.kill('TERM', pid) if force
+          result
+        end
+      end
+
+      class Windows < Rack::CustomProcess
+        def kill(pid, _force = true)
+          # Doesn't matter if its forceful or not. There's only one way of ending it
+          system("taskkill /pid #{pid} /T /f")
+          result = $CHILD_STATUS.exitstatus
+          if result == 0
+            UI.debug("Killed Rack (Exit status: #{result})")
+          else
+            UI.debug("Couldn't kill Rack")
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/guard/rack/runner.rb
+++ b/lib/guard/rack/runner.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
-require 'timeout'
 require 'spoon'
 require 'guard/rack/command'
+require 'guard/rack/custom_process'
 
 module Guard
   class RackRunner
@@ -38,26 +38,7 @@ module Guard
     private
 
     def kill(pid, force = false)
-      result = -1
-
-      UI.debug("Trying to kill Rack (PID #{pid})...")
-      unless force
-        Process.kill('INT', pid)
-        begin
-          Timeout.timeout(options[:timeout]) do
-            _, status = Process.wait2(pid)
-            result = status.exitstatus
-            UI.debug("Killed Rack (Exit status: #{result})")
-          end
-        rescue Timeout::Error
-          UI.debug("Couldn't kill Rack with INT, switching to TERM")
-          force = true
-        end
-      end
-
-      Process.kill('TERM', pid) if force
-
-      result
+      Guard::Rack::CustomProcess.new(options).kill pid, force
     end
 
     def run_rack_command!

--- a/spec/lib/guard/process_spec.rb
+++ b/spec/lib/guard/process_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+require 'guard/rack/custom_process'
+
+describe Guard::Rack::CustomProcess do
+  let(:options) { { environment: 'development', port: 'one', config: 'config.ru', host: '0.0.0.0', timeout: 1 } }
+  let(:process) { Guard::Rack::CustomProcess }
+
+  describe 'create instance' do
+    context '*nix' do
+      before do
+        Gem.stubs(:win_platform?).returns(false)
+      end
+
+      it 'should instantiate correctly' do
+        instance = process.new(options)
+        expect(instance).to be_a Guard::Rack::CustomProcess::Nix
+      end
+    end
+
+    context 'windows' do
+      before do
+        Gem.stubs(:win_platform?).returns(true)
+      end
+
+      it 'should instantiate correctly' do
+        instance = process.new(options)
+        expect(instance).to be_a Guard::Rack::CustomProcess::Windows
+      end
+    end
+  end
+
+  describe '*nix' do
+    before do
+      Gem.stubs(:win_platform?).returns(false)
+    end
+
+    context 'pid exists' do
+      let(:pid) { 12_345 }
+      let(:status_stub) { stub('process exit status') }
+      let(:subject) { process.new(options) }
+      let(:wait_stub) { Process.stubs(:wait2) }
+
+      before do
+        Process.expects(:kill).with('INT', pid)
+      end
+
+      context 'rackup returns successful exit status' do
+        before do
+          wait_stub.returns([pid, status_stub])
+          status_stub.stubs(:exitstatus).returns(0)
+        end
+
+        it 'should return true' do
+          expect(subject.kill pid).to eq(0)
+        end
+      end
+
+      context 'rackup returns unsuccessful exit status' do
+        before do
+          Guard::UI.stubs(:info)
+          wait_stub.returns([pid, status_stub])
+          status_stub.stubs(:exitstatus).returns(1)
+        end
+
+        it 'should return false' do
+          expect(subject.kill pid).to eq(1)
+        end
+      end
+
+      context 'kill times out' do
+        before do
+          wait_stub.raises(Timeout::Error)
+          Process.expects(:kill).with('TERM', pid)
+        end
+
+        it 'should return false' do
+          expect(subject.kill pid).to eq(-1)
+        end
+      end
+    end
+  end
+
+  describe 'windows' do
+    before do
+      Gem.stubs(:win_platform?).returns(true)
+    end
+
+    context 'pid exist' do
+      let(:pid) { 123_45 }
+      let(:subject) { process.new }
+      before do
+        subject.expects(:system).with("taskkill /pid #{pid} /T /f")
+      end
+
+      describe 'kill' do
+        context 'successful exit status' do
+          before do
+            $CHILD_STATUS.stubs(:exitstatus).returns 0
+          end
+
+          it 'should result in 0' do
+            expect(subject.kill pid).to eq(0)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I believe this might solve https://github.com/dblock/guard-rack/issues/22

Instead of using process, I can just send a shell command to do the job.

Althought its not async like Process but it is a workaround.