### PR TITLE
Fix builds for older rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.1.2
+  - 2.4.0
+  - 2.3.3
+  - 2.2.6
+  - 2.1.10
   - jruby-19mode
   - ruby-head
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.3.3
   - 2.2.6
   - 2.1.10
-  - jruby-19mode
+  - jruby
   - ruby-head
   - jruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 
 rvm:
   - 2.1.2
-  - 1.9.3
   - jruby-19mode
   - ruby-head
   - jruby-head

--- a/guard-rack.gemspec
+++ b/guard-rack.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'ffi'
   gem.add_dependency 'spoon'
 
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rake', '< 11'
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'fakefs'

--- a/guard-rack.gemspec
+++ b/guard-rack.gemspec
@@ -24,5 +24,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'fakefs'
   gem.add_development_dependency 'mocha', '~> 1.1'
-  gem.add_development_dependency 'rack'
+
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.0')
+    gem.add_development_dependency 'rack', '< 2'
+  else
+    gem.add_development_dependency 'rack', '~> 2'
+  end
 end


### PR DESCRIPTION
Rack 2 requires Ruby 2.2+. Since we test on 2.1, we need to clamp the
development dependency for Rack to < 2 when on the older Ruby.

I'm doing this programmatically instead of just doing it universally
because we *do* want to test on Rack 2 when we have a version of Ruby
that works with it. Since 2.1 is still in security-fix mode, it seems
like we should still test on it.

I also went through and updated the Travis configuration to drop 1.9
since it's EOL and add a newer 2.1 version along with 2.2, 2.3, and 2.4.
Lastly, I updated the Travis config to use the "jruby" alias instead of
the "jruby-19mode" alias, since modern JRuby runs with Ruby 2+
syntax.

This all should make it so the build for #24 can pass.