### PR TITLE
Don't short-circuit on stop when restarting

### DIFF
--- a/lib/guard/rack/runner.rb
+++ b/lib/guard/rack/runner.rb
@@ -32,7 +32,9 @@ module Guard
     end
 
     def restart
-      stop && start
+      stop
+      start
+      @pid ? true : false
     end
 
     private


### PR DESCRIPTION
Resolves https://github.com/dblock/guard-rack/issues/28.

Assume that there is syntactically valid code that is modified not to be syntactically valid. On save the `restart` method would run `stop` and then `start` but `start` would fail because of the invalid syntax.

Fixing the invalid syntax would again call `restart` which would call `stop` which would fail because the previous `start` invocation failed. This would short-circuit `restart` into failing.

(I think) the expected behavior is that `restart` should attempt to stop, then attempt to start, and then return success or failure based on whether or not `spawn` has succeeded and not on whether or not `stop` has succeeded. This PR does that.